### PR TITLE
Changes needed for one off gene import, version 38

### DIFF
--- a/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/core/Sources.java
+++ b/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/core/Sources.java
@@ -27,14 +27,14 @@ public final class Sources {
   /**
    * Versions.
    */
-  private static final int ASSEMBLY_VERSION = 37;
-  private static final int ENSEMBL_RELEASE = 82;
+  private static final int ASSEMBLY_VERSION = 38;
+  private static final int ENSEMBL_RELEASE = 100;
 
   /**
    * Ensembl files.
    */
   private static final String ENSEMBL_RELEASE_URI =
-      "ftp://ftp.ensembl.org/pub/grch" + ASSEMBLY_VERSION + "/release-" + ENSEMBL_RELEASE + "/";
+      "ftp://ftp.ensembl.org/pub/release-" + ENSEMBL_RELEASE + "/";
 
   public static final String GTF_URI =
       ENSEMBL_RELEASE_URI + "gtf/homo_sapiens/Homo_sapiens.GRCh" + ASSEMBLY_VERSION + "." + ENSEMBL_RELEASE + ".gtf.gz";

--- a/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/reader/EntrezReader.java
+++ b/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/reader/EntrezReader.java
@@ -99,17 +99,9 @@ public class EntrezReader {
   }
 
   private static String getDownload(String platform) {
-    if (platform.contains("Windows")) {
-      return BASE_URI + "gene2xml.win32.zip";
-    } else if (platform.contains("Mac")) {
-      return BASE_URI + "gene2xml.Darwin-13.4.0-x86_64.gz";
-    } else if (platform.contains("Linux")) {
-      return BASE_URI + "gene2xml.Linux-2.6.32-573.7.1.el6.x86_64-x86_64.gz";
-    } else if (platform.contains("Sun")) {
-      return BASE_URI + "gene2xml.SunOS-5.10-sun4v.gz";
-    } else {
-      throw new RuntimeException("Your platform is not supported for the dcc-import-gene project.");
-    }
+
+      return BASE_URI + "gene2xml.Darwin-15.6.0-x86_64.gz";
+    
   }
 
 }

--- a/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/reader/GeneMappingReader.java
+++ b/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/reader/GeneMappingReader.java
@@ -69,7 +69,7 @@ public class GeneMappingReader extends TsvReader {
   }
 
   private String getGeneId(List<String> record) {
-    return record.get(13);
+    return record.get(12);
   }
 
   private String getCanonicalTranscript(List<String> record) {
@@ -79,7 +79,7 @@ public class GeneMappingReader extends TsvReader {
   }
 
   private String getTranscriptId(List<String> record) {
-    return record.get(12);
+    return record.get(11);
   }
 
 }

--- a/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/reader/TranscriptReader.java
+++ b/dcc-import-gene/src/main/java/org/icgc/dcc/imports/gene/reader/TranscriptReader.java
@@ -50,7 +50,7 @@ public class TranscriptReader extends TsvReader {
   }
 
   private String getStableId(List<String> record) {
-    return record.get(14);
+    return record.get(13);
   }
 
   private String getGeneId(List<String> record) {

--- a/dcc-import-gene/src/test/java/org/icgc/dcc/imports/gene/GeneImporterTest.java
+++ b/dcc-import-gene/src/test/java/org/icgc/dcc/imports/gene/GeneImporterTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import lombok.val;
 
-@Ignore("For development only")
 public class GeneImporterTest {
 
   @Test

--- a/dcc-import-go/pom.xml
+++ b/dcc-import-go/pom.xml
@@ -84,6 +84,7 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -178,11 +178,13 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <version>1.18.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>findbugs-maven-plugin</artifactId>
+      <version>3.0.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
DO NOT MERGE - Just for reference.

Had several issues getting maven to successfully compile and run this thing. Specifying some versions in the POM solved some issues, but to get by the enforcer tests that fail use the `-Denforcer.skip=true` param with `mvn`. Since I only wanted the gene importer to run into my local mongo instance, I just ran the `GeneImporterTest.testExecute()` . This accomplished everything I needed:

`mvn -Dtest=GeneImporterTest#testExecute -Denforcer.skip=true test`

Also, for the EntrezReader download URL I found a version compatible with my OS and hardcoded the URL. That will need to be updated for whatever device is running the import.